### PR TITLE
Add CLI flags, new servers, and summary generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,24 @@ Benchmarks comparing Solidity LSP servers against Uniswap V4-core (`Pool.sol`, 6
 - **Our LSP** — [solidity-language-server](https://github.com/mmsaki/solidity-language-server) (Rust)
 - **solc** — Solidity compiler built-in LSP (C++)
 - **nomicfoundation** — nomicfoundation-solidity-language-server (Node.js)
+- **juanfranblanco** — vscode-solidity-server (Node.js)
+- **qiuxiang** — solidity-ls (TypeScript)
 
 ## Results
 
-| Benchmark | Our LSP | solc | nomicfoundation |
-|-----------|---------|------------|---------------|
-| Spawn + Init | 3ms ⚡ | 123ms | 867ms |
-| Diagnostics | 435ms | 133ms ⚡ | 911ms |
-| Go to Definition | 8.8ms ⚡ | - | timeout |
-| Go to Declaration | 8.9ms ⚡ | unsupported | timeout |
-| Find References | 10.2ms ⚡ | unsupported | timeout |
-| Document Symbols | 9.0ms ⚡ | unsupported | timeout |
+# Solidity LSP Benchmark Results
+
+10 iterations, 2 warmup, 10s timeout
+
+| Benchmark | Our LSP | solc | nomicfoundation | juanfranblanco | qiuxiang |
+|-----------|---------|------|-----------------|----------------|----------|
+| Spawn + Init | 4.1ms ⚡ | 122.5ms | 860.6ms | 510.2ms | 67.4ms |
+| Diagnostics | 650.0ms | 132.5ms ⚡ | 914.3ms | FAIL | 256.6ms |
+| Go to Definition | 27.0ms ⚡ | - | timeout | FAIL | timeout |
+| Go to Declaration | 31.0ms ⚡ | - | timeout | FAIL | timeout |
+| Hover | - | - | timeout | FAIL | timeout |
+| Find References | 20.7ms ⚡ | - | timeout | FAIL | timeout |
+| Document Symbols | 22.2ms ⚡ | - | timeout | FAIL | timeout |
 
 Detailed results per benchmark in [results/](./results).
 
@@ -25,7 +32,9 @@ Detailed results per benchmark in [results/](./results).
 
 - [solidity-language-server](https://github.com/mmsaki/solidity-language-server): `cargo install solidity-language-server`
 - [solc](https://docs.soliditylang.org/en/latest/installing-solidity.html)
-- [nomicfoundation-solidity-language-server](https://github.com/NomicFoundation/hardhat-vscode)
+- [nomicfoundation-solidity-language-server](https://github.com/NomicFoundation/hardhat-vscode) `npm i -g @nomicfoundation/solidity-language-server`
+- [vscode-solidity-server](https://github.com/juanfranblanco/vscode-solidity): `npm i -g vscode-solidity-server`
+- [solidity-ls](https://github.com/qiuxiang/solidity-ls): `npm i -g solidity-ls`
 
 ## Run
 
@@ -33,10 +42,40 @@ Detailed results per benchmark in [results/](./results).
 git clone --recursive https://github.com/mmsaki/solidity-lsp-benchmarks.git
 cd solidity-lsp-benchmarks
 cargo build --release
-./target/release/bench <subcommand>
+./target/release/bench [OPTIONS] <COMMAND>
 ```
 
-Subcommands: `spawn`, `diagnostics`, `definition`, `declaration`, `hover`, `references`, `documentSymbol`
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `all` | Run all benchmarks |
+| `spawn` | Spawn + initialize handshake |
+| `diagnostics` | Open Pool.sol, time to first diagnostic |
+| `definition` | Go-to-definition on TickMath in Pool.sol |
+| `declaration` | Go-to-declaration on TickMath in Pool.sol |
+| `hover` | Hover on TickMath in Pool.sol |
+| `references` | Find references on TickMath in Pool.sol |
+| `documentSymbol` | Get document symbols for Pool.sol |
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-n, --iterations` | 10 | Number of measured iterations |
+| `-w, --warmup` | 2 | Number of warmup iterations |
+| `-t, --timeout` | 30 | Timeout per request in seconds |
+| `-h, --help` | | Show help message |
+
+### Examples
+
+```sh
+bench all                   # Run all benchmarks (10 iterations, 2 warmup)
+bench all -n 1 -w 0         # Run all benchmarks once, no warmup
+bench diagnostics -n 5      # Run diagnostics with 5 iterations
+bench spawn definition      # Run specific benchmarks
+bench all -t 10             # Run all benchmarks with 10s timeout
+```
 
 ## Methodology
 

--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,23 @@
+# Solidity LSP Benchmark Results
+
+10 iterations, 2 warmup, 10s timeout
+
+| Benchmark | Our LSP | solc | nomicfoundation | juanfranblanco | qiuxiang |
+|-----------|---------|------|-----------------|----------------|----------|
+| Spawn + Init | 4.1ms ⚡ | 122.5ms | 860.6ms | 510.2ms | 67.4ms |
+| Diagnostics | 650.0ms | 132.5ms ⚡ | 914.3ms | FAIL | 256.6ms |
+| Go to Definition | 27.0ms ⚡ | - | timeout | FAIL | timeout |
+| Go to Declaration | 31.0ms ⚡ | - | timeout | FAIL | timeout |
+| Hover | - | - | timeout | FAIL | timeout |
+| Find References | 20.7ms ⚡ | - | timeout | FAIL | timeout |
+| Document Symbols | 22.2ms ⚡ | - | timeout | FAIL | timeout |
+
+Detailed results per benchmark:
+
+- [spawn](./spawn.md)
+- [diagnostics](./diagnostics.md)
+- [definition](./definition.md)
+- [declaration](./declaration.md)
+- [hover](./hover.md)
+- [references](./references.md)
+- [documentSymbol](./documentSymbol.md)

--- a/results/declaration.md
+++ b/results/declaration.md
@@ -7,18 +7,20 @@ Waits for valid publishDiagnostics before sending requests.
 
 | Server | p50 | p95 | mean |
 |--------|-----|-----|------|
-| Our LSP | 8.3 ⚡ | 9.3 ⚡ | 8.4 ⚡ |
+| Our LSP | 27.5 ⚡ | 77.2 ⚡ | 31.0 ⚡ |
 | solc | - | - | - |
 | nomicfoundation | FAIL | FAIL | FAIL |
+| juanfranblanco | FAIL | FAIL | FAIL |
+| qiuxiang | FAIL | FAIL | FAIL |
 
 ### Responses
 
-**Our LSP**  [diag: 4 in 424ms]
+**Our LSP**  [diag: 4 in 425ms]
 ```json
 {"range":{"end":{"character":8,"line":9},"start":{"character":8,"line":9}},"uri":"file:///Users/meek/developer/mmsaki/so...
 ```
 
-**solc**  [diag: 1 in 132ms]
+**solc**  [diag: 1 in 138ms]
 ```
 error: Unknown method textDocument/declaration
 ```
@@ -28,5 +30,15 @@ error: Unknown method textDocument/declaration
 FAIL: wait_for_diagnostics: timeout
 ```
 
+**juanfranblanco**
+```
+FAIL: wait_for_diagnostics: EOF
+```
 
-Our LSP {"range":{"end":{"character":8,"line":9},"start":{"character":8,"line":9}},"uri":"file:///Users/meek/developer/mmsaki/so..., solc error: Unknown method textDocument/declaration, nomicfoundation timeout.
+**qiuxiang**
+```
+FAIL: wait_for_diagnostics: timeout
+```
+
+
+Our LSP 31.0ms, solc unsupported, nomicfoundation timeout, juanfranblanco timeout, qiuxiang timeout.

--- a/results/definition.md
+++ b/results/definition.md
@@ -7,18 +7,20 @@ Waits for valid publishDiagnostics before sending requests.
 
 | Server | p50 | p95 | mean |
 |--------|-----|-----|------|
-| Our LSP | 8.5 ⚡ | 9.1 ⚡ | 8.5 ⚡ |
+| Our LSP | 18.0 ⚡ | 89.0 ⚡ | 27.0 ⚡ |
 | solc | - | - | - |
 | nomicfoundation | FAIL | FAIL | FAIL |
+| juanfranblanco | FAIL | FAIL | FAIL |
+| qiuxiang | FAIL | FAIL | FAIL |
 
 ### Responses
 
-**Our LSP**  [diag: 4 in 420ms]
+**Our LSP**  [diag: 4 in 410ms]
 ```json
 {"range":{"end":{"character":8,"line":9},"start":{"character":8,"line":9}},"uri":"file:///Users/meek/developer/mmsaki/so...
 ```
 
-**solc**  [diag: 1 in 131ms]
+**solc**  [diag: 1 in 137ms]
 ```
 []
 ```
@@ -28,5 +30,15 @@ Waits for valid publishDiagnostics before sending requests.
 FAIL: wait_for_diagnostics: timeout
 ```
 
+**juanfranblanco**
+```
+FAIL: wait_for_diagnostics: EOF
+```
 
-solc returns [], Our LSP {"range":{"end":{"character":8,"line":9},"start":{"character":8,"line":9}},"uri":"file:///Users/meek/developer/mmsaki/so..., nomicfoundation timeout.
+**qiuxiang**
+```
+FAIL: wait_for_diagnostics: timeout
+```
+
+
+Our LSP 27.0ms, solc no result, nomicfoundation timeout, juanfranblanco timeout, qiuxiang timeout.

--- a/results/diagnostics.md
+++ b/results/diagnostics.md
@@ -5,28 +5,38 @@ Measures: didOpen notification -> first publishDiagnostics response
 
 | Server | p50 | p95 | mean |
 |--------|-----|-----|------|
-| Our LSP | 409.1 | 416.9 | 409.8 |
-| solc | 130.2 ⚡ | 132.4 ⚡ | 130.1 ⚡ |
-| nomicfoundation | 914.6 | 922.9 | 914.7 |
+| Our LSP | 648.3 | 668.9 | 650.0 |
+| solc | 131.6 ⚡ | 138.1 ⚡ | 132.5 ⚡ |
+| nomicfoundation | 914.7 | 922.6 | 914.3 |
+| juanfranblanco | FAIL | FAIL | FAIL |
+| qiuxiang | 256.4 | 265.6 | 256.6 |
 
 ### Responses
 
 **Our LSP**
-
 ```json
 "4 diagnostics: [3] [forge lint] function names should use mixedCase (forge-lint); [3] [forge lint] mutable variables sh...
 ```
 
 **solc**
-
 ```json
 "no diagnostics"
 ```
 
 **nomicfoundation**
-
 ```json
 "no diagnostics"
 ```
 
-solc fastest diagnostics (130ms), Our LSP 410ms with , nomicfoundation 915ms with no diags.
+**juanfranblanco**
+```
+FAIL: EOF
+```
+
+**qiuxiang**
+```json
+"no diagnostics"
+```
+
+
+solc fastest diagnostics (133ms), qiuxiang 257ms, Our LSP 650ms, nomicfoundation 914ms, juanfranblanco fail.

--- a/results/documentSymbol.md
+++ b/results/documentSymbol.md
@@ -6,18 +6,20 @@ Waits for valid publishDiagnostics before sending requests.
 
 | Server | p50 | p95 | mean |
 |--------|-----|-----|------|
-| Our LSP | 8.4 ⚡ | 8.6 ⚡ | 8.3 ⚡ |
+| Our LSP | 21.1 ⚡ | 35.8 ⚡ | 22.2 ⚡ |
 | solc | - | - | - |
 | nomicfoundation | FAIL | FAIL | FAIL |
+| juanfranblanco | FAIL | FAIL | FAIL |
+| qiuxiang | FAIL | FAIL | FAIL |
 
 ### Responses
 
-**Our LSP**  [diag: 4 in 424ms]
+**Our LSP**  [diag: 4 in 420ms]
 ```json
 [{"kind":15,"name":"solidity ^0.8.0","range":{"end":{"character":23,"line":1},"start":{"character":0,"line":1}},"selecti...
 ```
 
-**solc**  [diag: 1 in 130ms]
+**solc**  [diag: 1 in 139ms]
 ```
 error: Unknown method textDocument/documentSymbol
 ```
@@ -27,5 +29,15 @@ error: Unknown method textDocument/documentSymbol
 FAIL: wait_for_diagnostics: timeout
 ```
 
+**juanfranblanco**
+```
+FAIL: wait_for_diagnostics: EOF
+```
 
-Our LSP fast (8.3ms) returns symbols, solc unsupported, nomicfoundation timeout.
+**qiuxiang**
+```
+FAIL: wait_for_diagnostics: timeout
+```
+
+
+Our LSP 22.2ms, solc unsupported, nomicfoundation timeout, juanfranblanco timeout, qiuxiang timeout.

--- a/results/hover.md
+++ b/results/hover.md
@@ -10,15 +10,17 @@ Waits for valid publishDiagnostics before sending requests.
 | Our LSP | - | - | - |
 | solc | - | - | - |
 | nomicfoundation | FAIL | FAIL | FAIL |
+| juanfranblanco | FAIL | FAIL | FAIL |
+| qiuxiang | FAIL | FAIL | FAIL |
 
 ### Responses
 
-**Our LSP**  [diag: 4 in 420ms]
+**Our LSP**  [diag: 4 in 414ms]
 ```
 error: Method not found
 ```
 
-**solc**  [diag: 1 in 131ms]
+**solc**  [diag: 1 in 194ms]
 ```
 null
 ```
@@ -28,5 +30,15 @@ null
 FAIL: wait_for_diagnostics: timeout
 ```
 
+**juanfranblanco**
+```
+FAIL: wait_for_diagnostics: EOF
+```
 
-Our LSP error: Method not found, solc null, nomicfoundation timeout.
+**qiuxiang**
+```
+FAIL: wait_for_diagnostics: timeout
+```
+
+
+Our LSP error: Method not found, solc null, nomicfoundation timeout, juanfranblanco timeout, qiuxiang timeout.

--- a/results/references.md
+++ b/results/references.md
@@ -7,18 +7,20 @@ Waits for valid publishDiagnostics before sending requests.
 
 | Server | p50 | p95 | mean |
 |--------|-----|-----|------|
-| Our LSP | 10.0 ⚡ | 11.0 ⚡ | 10.1 ⚡ |
+| Our LSP | 16.6 ⚡ | 38.1 ⚡ | 20.7 ⚡ |
 | solc | - | - | - |
 | nomicfoundation | FAIL | FAIL | FAIL |
+| juanfranblanco | FAIL | FAIL | FAIL |
+| qiuxiang | FAIL | FAIL | FAIL |
 
 ### Responses
 
-**Our LSP**  [diag: 4 in 427ms]
+**Our LSP**  [diag: 4 in 433ms]
 ```json
-[{"range":{"end":{"character":32,"line":95},"start":{"character":24,"line":95}},"uri":"file:///Users/meek/developer/mmsa...
+[{"range":{"end":{"character":40,"line":354},"start":{"character":32,"line":354}},"uri":"file:///Users/meek/developer/mm...
 ```
 
-**solc**  [diag: 1 in 132ms]
+**solc**  [diag: 1 in 133ms]
 ```
 error: Unknown method textDocument/references
 ```
@@ -28,5 +30,15 @@ error: Unknown method textDocument/references
 FAIL: wait_for_diagnostics: timeout
 ```
 
+**juanfranblanco**
+```
+FAIL: wait_for_diagnostics: EOF
+```
 
-Our LSP [{"range":{"end":{"character":32,"line":95},"start":{"character":24,"line":95}},"uri":"file:///Users/meek/developer/mmsa..., solc error: Unknown method textDocument/references, nomicfoundation timeout.
+**qiuxiang**
+```
+FAIL: wait_for_diagnostics: timeout
+```
+
+
+Our LSP 20.7ms, solc unsupported, nomicfoundation timeout, juanfranblanco timeout, qiuxiang timeout.

--- a/results/spawn.md
+++ b/results/spawn.md
@@ -5,9 +5,11 @@ No files opened.
 
 | Server | p50 | p95 | mean |
 |--------|-----|-----|------|
-| Our LSP | 5.0 ⚡ | 5.4 ⚡ | 4.7 ⚡ |
-| solc | 121.6 | 124.0 | 121.7 |
-| nomicfoundation | 882.0 | 891.9 | 878.9 |
+| Our LSP | 4.0 ⚡ | 5.3 ⚡ | 4.1 ⚡ |
+| solc | 123.0 | 125.4 | 122.5 |
+| nomicfoundation | 861.2 | 886.8 | 860.6 |
+| juanfranblanco | 509.5 | 513.8 | 510.2 |
+| qiuxiang | 67.3 | 68.4 | 67.4 |
 
 ### Responses
 
@@ -26,5 +28,15 @@ No files opened.
 "ok"
 ```
 
+**juanfranblanco**
+```json
+"ok"
+```
 
-Our LSP fastest startup (5ms), solc 122ms, nomicfoundation 879ms.
+**qiuxiang**
+```json
+"ok"
+```
+
+
+Our LSP fastest startup (4ms), qiuxiang 67ms, solc 123ms, juanfranblanco 510ms, nomicfoundation 861ms.


### PR DESCRIPTION
## Summary

- Rename display labels to proper names: `Hardhat/Nomic` → `nomicfoundation`, `solc --lsp` → `solc`
- Add two new LSP servers: **juanfranblanco** (`vscode-solidity-server`) and **qiuxiang** (`solidity-ls`)
- Add CLI flags: `-n/--iterations`, `-w/--warmup`, `-t/--timeout`, and `all` command
- Generate `results/README.md` summary table when running `bench all`
- Rewrite `generate_summary` to handle arbitrary number of servers dynamically
- Update benchmark results with all 5 servers

## CLI Usage

```sh
bench all                   # Run all benchmarks (10 iter, 2 warmup)
bench all -n 1 -w 0         # Run all benchmarks once, no warmup
bench diagnostics -n 5      # Run diagnostics with 5 iterations
bench all -t 10             # Run all benchmarks with 10s timeout
```