### PR TITLE
feat: --verify flag for expectation checking

### DIFF
--- a/examples/benchmark.template.yaml
+++ b/examples/benchmark.template.yaml
@@ -49,11 +49,16 @@ report_style: readme    # delta (default), readme, or analysis
 readme: 
   - Counter.md
 
-# Per-method position and trigger overrides (optional)
+# Per-method position, trigger, and expected result overrides (optional)
 # Each method can have its own line/col and trigger character.
 # Methods not listed here use the global line/col above.
 # Only list methods you want to override — omit the rest.
 # The trigger field is only used for textDocument/completion.
+#
+# The expect field defines the expected response for --verify mode.
+# When running `lsp-bench --verify`, responses are checked against
+# expect.file (URI suffix match) and expect.line (0-based line number).
+# Exits non-zero if any expectation fails.
 #
 # methods:
 #   textDocument/completion:
@@ -64,6 +69,16 @@ readme:
 #   textDocument/definition:
 #     line: 200
 #     col: 15
+#     expect:                    # expected result for --verify
+#       file: MyContract.sol     # response URI must end with this
+#       line: 42                 # response range.start.line must match
+#     didChange:
+#       - file: src/MyContract.v2.sol
+#         line: 201
+#         col: 15
+#         expect:                # per-snapshot expect (overrides method-level)
+#           file: MyContract.sol
+#           line: 42
 
 # Response output (default: 80)
 #   full     -> store full response, no truncation


### PR DESCRIPTION
## Summary

- Add `--verify` CLI flag that checks LSP responses against expected values declared in benchmark configs
- Add `expect` field to `MethodConfig` and `FileSnapshot` with `file` (URI suffix) and `line` (0-based) matchers
- Print per-snapshot pass/fail with clear error messages, exit non-zero on any mismatch

## Usage

Add `expect` to your config:

```yaml
methods:
  textDocument/definition:
    line: 217
    col: 26
    expect:
      file: SafeCast.sol
      line: 39
    didChange:
      - file: Pool.sol.dirty
        line: 216
        col: 22
        expect:           # per-snapshot override (optional)
          file: SafeCast.sol
          line: 39
```

Run with `--verify`:

```
$ lsp-bench --config goto-toInt128.yaml --verify

[1/1] textDocument/definition
  edit 4 snapshot(s) via didChange
  ✓ [1] Pool.sol.chain0
  ✓ [2] Pool.sol.toint128_dirty
  ✓ [3] Pool.sol.chain1
  ✓ [4] Pool.sol.chain2

  verify 4/4 expectations passed
```

On failure:

```
  ✗ mmsaki — line: expected 999 but got 147

  verify 1/1 expectations failed
$ echo $?
1
```

## Tested

Verified against 5 benchmark configs from solidity-language-server issue #82 (15/15 expectations pass across TickMath, delta, SqrtPriceMath, and toInt128 goto-definition tests with dirty/clean file snapshots).

Fixes #14