### PR TITLE
feat: add exclude config to skip unimplemented methods

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -339,6 +339,8 @@ struct Config {
     output: String,
     #[serde(default)]
     benchmarks: Vec<String>,
+    #[serde(default)]
+    exclude: Vec<String>,
     /// Output path for the generated report. Omit to skip report generation.
     #[serde(default)]
     report: Option<String>,
@@ -2593,12 +2595,21 @@ fn main() {
     let partial_dir = format!("{}/partial", output_dir);
 
     // Resolve which benchmarks to run from config
-    let benchmarks: Vec<&str> =
-        if cfg.benchmarks.is_empty() || cfg.benchmarks.iter().any(|c| c == "all") {
-            ALL_BENCHMARKS.to_vec()
+    let benchmarks: Vec<&str> = {
+        let base: Vec<&str> =
+            if cfg.benchmarks.is_empty() || cfg.benchmarks.iter().any(|c| c == "all") {
+                ALL_BENCHMARKS.to_vec()
+            } else {
+                cfg.benchmarks.iter().map(|s| s.as_str()).collect()
+            };
+        if cfg.exclude.is_empty() {
+            base
         } else {
-            cfg.benchmarks.iter().map(|s| s.as_str()).collect()
-        };
+            base.into_iter()
+                .filter(|b| !cfg.exclude.iter().any(|e| e == b))
+                .collect()
+        }
+    };
 
     for b in &benchmarks {
         if !ALL_BENCHMARKS.contains(b) {


### PR DESCRIPTION
## Summary

- Adds an `exclude` list to the config YAML that filters out methods from the benchmark run
- Useful for skipping methods a server hasn't implemented yet instead of listing all supported methods individually in `benchmarks`
- Works with `benchmarks: [all]` — run everything except the excluded methods

```yaml
exclude:
  - textDocument/typeDefinition
  - textDocument/foldingRange
  - textDocument/codeLens
```